### PR TITLE
Fix agent classification and configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,17 +99,26 @@ agents:
     description: "Handles GitLab project queries"
     host: "127.0.0.1"
     port: 2024
+    keywords:
+      - gitlab
+      - merge request
+      - pipeline
   jira:
     name: "Jira Assistant"
     description: "Handles Jira ticket queries"
     host: "127.0.0.1"
     port: 2025
+    keywords:
+      - jira
+      - ticket
+      - sprint
 ```
 
 - **`agents`**: The root key.
-- **`gitlab` / `jira`**: These are the `agent_key`s. The `classify` node uses these keys to identify the agent. The keyword search is hard-coded to match these keys.
+- **`gitlab` / `jira`**: These are the `agent_key`s. The `classify` node uses these keys to identify the agent. The keyword search is configurable via the optional `keywords` list.
 - **`name`**: The official name of the assistant. This is used during the discovery phase to find the correct `assistant_id`.
 - **`host` / `port`**: The address of the target agent's service.
+- **`keywords`**: Optional list of keywords that should be matched during the classification step. If omitted, the agent key itself is used as the default keyword.
 
 ### Adding a New Agent
 
@@ -127,19 +136,7 @@ agents:
     ```
 
 2.  **Update the `classify` Node**:
-    Open `src/agentic_router/nodes/classify.py` and add a condition to recognize keywords for your new agent.
-
-    ```python
-    # In classify.py
-    # ...
-    if "gitlab" in lower_input:
-        agent_key = "gitlab"
-    elif "jira" in lower_input:
-        agent_key = "jira"
-    elif "notion" in lower_input: # Add this
-        agent_key = "notion"
-    # ...
-    ```
+    Add relevant keywords under the agent definition. The classifier automatically uses the configured keywords without further code changes.
 
 ## Troubleshooting
 

--- a/src/agentic_router/agents_config.yaml
+++ b/src/agentic_router/agents_config.yaml
@@ -4,8 +4,16 @@ agents:
     description: "Handles GitLab project queries"
     host: "127.0.0.1"
     port: 2024
-  Pishool:
+    keywords:
+      - gitlab
+      - merge request
+      - pipeline
+  pishool:
     name: "Pishool"
-    description: "Handles Opensearch queriesticket queries"
-    host: "https://logagent-part2.partdp.ai
+    description: "Handles OpenSearch and log related queries"
+    host: "logagent-part2.partdp.ai"
     port: 443
+    keywords:
+      - pishool
+      - opensearch
+      - log agent

--- a/src/agentic_router/agents_config.yaml.example
+++ b/src/agentic_router/agents_config.yaml.example
@@ -4,8 +4,14 @@ agents:
     description: "Handles GitLab project queries"
     host: "127.0.0.1"
     port: 2024
+    keywords:
+      - gitlab
+      - merge request
   jira:
     name: "Jira Assistant"
     description: "Handles Jira ticket queries"
     host: "127.0.0.1"
     port: 2025
+    keywords:
+      - jira
+      - ticket

--- a/src/agentic_router/nodes/classify.py
+++ b/src/agentic_router/nodes/classify.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 from typing import Any, Dict
 
+from ..config import AGENTS_CONFIG
 from ..types import AgentState
 from .utils import extract_latest_user_message
 
@@ -21,10 +22,11 @@ async def classify(state: AgentState) -> Dict[str, Any]:
     lower_input = input_text.lower()
     agent_key = None
 
-    if "gitlab" in lower_input:
-        agent_key = "gitlab"
-    elif "jira" in lower_input:
-        agent_key = "jira"
+    for key, config in AGENTS_CONFIG.items():
+        keywords = config.keywords or [key]
+        if any(keyword.lower() in lower_input for keyword in keywords):
+            agent_key = key
+            break
 
     if not agent_key:
         logger.error("No matching agent found for the input.")

--- a/src/agentic_router/types.py
+++ b/src/agentic_router/types.py
@@ -10,9 +10,19 @@ class ToolConfig(BaseModel):
     """Pydantic model for a single agent's configuration."""
 
     name: str = Field(..., description="The name of the agent.")
-    description: str = Field(..., description="A brief description of the agent's purpose.")
-    host: str = Field(..., description="The hostname or IP address of the agent's service.")
+    description: str = Field(
+        ...,
+        description="A brief description of the agent's purpose.",
+    )
+    host: str = Field(
+        ...,
+        description="The hostname or IP address of the agent's service (without protocol).",
+    )
     port: int = Field(..., description="The port number for the agent's service.")
+    keywords: list[str] = Field(
+        default_factory=list,
+        description="List of keywords that should route requests to this agent.",
+    )
 
 
 class AgentsConfig(BaseModel):


### PR DESCRIPTION
## Summary
- add keyword support to agent configuration and update classifier to use the configured keywords when routing messages
- repair the default agents_config.yaml and document the new keywords field for downstream consumers

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d7c396db1483268c57ae494bfb8c14