### PR TITLE
Support protocol-prefixed agent hosts

### DIFF
--- a/src/agentic_router/nodes/discover.py
+++ b/src/agentic_router/nodes/discover.py
@@ -9,6 +9,7 @@ import httpx
 
 from ..config import AGENTS_CONFIG
 from ..types import AgentState
+from .utils import build_service_url
 
 logger = logging.getLogger(__name__)
 
@@ -27,7 +28,7 @@ async def discover(state: AgentState) -> Dict[str, Any]:
     port = agent_config.port
     expected_name = agent_config.name
 
-    url = f"http://{host}:{port}/assistants/search"
+    url = build_service_url(host, port, "/assistants/search")
     logger.info("Discovering assistant_id for '%s' at %s", expected_name, url)
 
     try:

--- a/src/agentic_router/nodes/forward.py
+++ b/src/agentic_router/nodes/forward.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, Optional
 import httpx
 
 from ..types import AgentState
-from .utils import extract_latest_user_message
+from .utils import build_service_url, extract_latest_user_message
 
 
 logger = logging.getLogger(__name__)
@@ -47,7 +47,7 @@ async def forward(state: AgentState) -> Dict[str, Any]:
     thread_id = state.get("active_thread_id")
 
 
-    url = f"http://{host}:{port}/a2a/{assistant_id}"
+    url = build_service_url(host, port, f"/a2a/{assistant_id}")
     payload = build_json_rpc_payload(input_text, thread_id)
     headers = {"Accept": "application/json"}
 

--- a/src/agentic_router/nodes/utils.py
+++ b/src/agentic_router/nodes/utils.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 from typing import Iterable
+from urllib.parse import urljoin, urlparse, urlunparse
 
 from langchain_core.messages import BaseMessage
 
@@ -46,4 +47,48 @@ def extract_latest_user_message(messages: Iterable[BaseMessage]) -> str:
         logger.debug("Skipping unsupported human message content: %s", content)
 
     raise ValueError("No human message found in state; cannot continue workflow.")
+
+
+def build_service_url(host: str, port: int, endpoint: str) -> str:
+    """Return a fully qualified URL for the downstream service endpoint.
+
+    ``host`` may be specified either as a bare hostname/IP (``example.com``) or with an
+    explicit protocol prefix (``https://example.com``). When no protocol is provided the
+    service defaults to HTTP. A port from the configuration is appended unless the host
+    already includes one.
+    """
+
+    parsed = urlparse(host)
+
+    has_protocol = parsed.scheme and "://" in host
+
+    if has_protocol:
+        netloc = parsed.netloc
+        path = parsed.path
+
+        if not netloc:
+            raise ValueError("Host must include a hostname when a protocol is provided.")
+
+        if parsed.port is None:
+            tail = netloc.split("]")[-1]
+            if ":" not in tail:
+                netloc = f"{netloc}:{port}"
+
+        base = urlunparse((parsed.scheme, netloc, path.rstrip("/"), "", "", ""))
+    else:
+        pseudo = urlparse(f"//{host}")
+        netloc = pseudo.netloc or pseudo.path or host
+
+        if not netloc:
+            raise ValueError("Host cannot be empty.")
+
+        if pseudo.port is None and ":" not in netloc.split(']')[-1]:
+            # Append the configured port only when the host value does not already provide
+            # one. ``split(']')[-1]`` keeps IPv6 literals intact while examining any
+            # trailing ``:port`` section outside of the closing bracket.
+            netloc = f"{netloc}:{port}"
+
+        base = urlunparse(("http", netloc, "", "", "", ""))
+
+    return urljoin(base.rstrip("/") + "/", endpoint.lstrip("/"))
 

--- a/src/agentic_router/types.py
+++ b/src/agentic_router/types.py
@@ -16,7 +16,9 @@ class ToolConfig(BaseModel):
     )
     host: str = Field(
         ...,
-        description="The hostname or IP address of the agent's service (without protocol).",
+        description=(
+            "The hostname, IP address, or fully qualified base URL for the agent's service."
+        ),
     )
     port: int = Field(..., description="The port number for the agent's service.")
     keywords: list[str] = Field(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,53 @@
+import pytest
+
+from agentic_router.nodes.utils import build_service_url
+
+
+@pytest.mark.parametrize(
+    "host, port, endpoint, expected",
+    [
+        ("example.com", 8080, "/assistants/search", "http://example.com:8080/assistants/search"),
+        (
+            "https://example.com",
+            443,
+            "assistants/search",
+            "https://example.com:443/assistants/search",
+        ),
+        (
+            "https://example.com:9000",
+            8080,
+            "/a2a/agent",
+            "https://example.com:9000/a2a/agent",
+        ),
+        (
+            "https://example.com/base",
+            9000,
+            "assistants/search",
+            "https://example.com:9000/base/assistants/search",
+        ),
+        (
+            "example.com:7000",
+            8080,
+            "a2a/agent",
+            "http://example.com:7000/a2a/agent",
+        ),
+        (
+            "https://[2001:db8::1]",
+            9000,
+            "assistants/search",
+            "https://[2001:db8::1]:9000/assistants/search",
+        ),
+    ],
+)
+def test_build_service_url(host, port, endpoint, expected):
+    assert build_service_url(host, port, endpoint) == expected
+
+
+def test_build_service_url_requires_hostname_with_protocol():
+    with pytest.raises(ValueError):
+        build_service_url("https://", 8000, "/assistants/search")
+
+
+def test_build_service_url_rejects_empty_host():
+    with pytest.raises(ValueError):
+        build_service_url("", 8000, "/assistants/search")


### PR DESCRIPTION
## Summary
- add a shared URL builder that normalises agent host values with or without a protocol
- update the discover and forward nodes to use the helper so HTTPS endpoints are supported
- document the host field expectations and add regression tests for the URL builder

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d7c6caea448326bd8fba08252c96d5